### PR TITLE
Customized scraping for some sources

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -45,9 +45,6 @@ def scrape_func(address, website, COLL):
         if website == 'xinhua':
             page_url = result.url.encode('ascii')
             page_url = page_url.replace('"', '')
-        if website == 'haaretz':
-            page_url = result.url.encode('ascii')
-            page_url = page_url.replace('"', '')
         if website == 'upi':
             page_url = result.url.encode('ascii')
             text = pages_scrape.scrape(page_url)


### PR DESCRIPTION
**UPI** wasn't scraping correctly, but now it is (cleaned up links so they could be followed). I also have it delete a few sentences of UPI information at the end of each story.

**BBC**\- removed a few sentences from each article about not getting the best viewing experience because our browser doesn't render CSS correctly (ha).

Added **Haaretz**, but took it back out. The website requires clicking through an intermediary page between RSS and story and requires a subscription.

**All other sources** checked out fine, except...

**Two remaining issues with Google News**: 
1. Google news stories have a different URL from the story reported on the original page, so using URLs to check for duplicates in MongoDB doesn't work in this case. (e.g. "nytimes.com/africa/some-story" vs. "news.google.com/aslkdjflsakdf/nytimes.com/africa/some-story")
2. In a few cases, comments on articles in Google news got scraped, too. (Specifically, stories from Time.com)
