### PR TITLE
Disable Goose image downloading

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -96,7 +96,8 @@ def _parse_results(rss_results, website, db_collection):
                         stored.
     """
     goose_extractor = Goose({'use_meta_language': False,
-                             'target_language': 'en'})
+                             'target_language': 'en',
+                             'enable_image_fetching': False})
 
     for result in rss_results:
         if website == 'xinhua':


### PR DESCRIPTION
I was getting "cannot identify image file" error, e.g. on Yemen Times. We don't want images at all, so I disabled image fetching in Goose.
