### PR TITLE
Commented out signal.signal line that breaks stuff.

### DIFF
--- a/scraper_sched.py
+++ b/scraper_sched.py
@@ -18,7 +18,7 @@ def timeout(seconds=10, error_message=os.strerror(errno.ETIME)):
             raise TimeoutError(error_message)
 
         def wrapper(*args, **kwargs):
-            signal.signal(signal.SIGALRM, _handle_timeout)
+            #signal.signal(signal.SIGALRM, _handle_timeout)
             signal.alarm(seconds)
             try:
                 result = func(*args, **kwargs)


### PR DESCRIPTION
Fixes issue #76. scraper_sched still works and logs, but doesn't throw an error due to multithreading problem with signal.